### PR TITLE
Replaced the dependency kotlin-stdlib-jdk8 with kotlin-stdlib

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <dependencies>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-stdlib-jdk8</artifactId>
+            <artifactId>kotlin-stdlib</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>


### PR DESCRIPTION
## Describe the changes

Replaced the dependency kotlin-stdlib-jdk8 with kotlin-stdlib.

ref) https://spring.io/guides/tutorials/spring-boot-kotlin
